### PR TITLE
Tasks schema now has `claimedBy`

### DIFF
--- a/server/models/Task.js
+++ b/server/models/Task.js
@@ -24,6 +24,10 @@ var Task = db.define('task', {
     type: Sequelize.BOOLEAN,
     allowNull: true
   },
+  claimedBy: {
+    type: Sequelize.INTEGER,
+    allowNull: true,
+  },
 }, {
   instanceMethods: {
     complete: function(userId) {


### PR DESCRIPTION
Through Sequelize ORM, the `tasks` table should now have a `claimedBy` column that can be `null`; in other words, tasks can be claimed/unclaimed.
